### PR TITLE
Update to 3.6.0 to publish ECC support

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: openpgp
 description: library for use OpenPGP with support for android and ios, macOS, linux, windows, web and hover
-version: 3.5.0
+version: 3.6.0
 homepage: https://github.com/jerson/flutter-openpgp
 
 environment:


### PR DESCRIPTION
Hi @jerson I saw that you already implemented ECC support, I want to use that but to avoid pointing to the branch(ecc/main) it would be nice to have it already in the pub.dev, I see everything is ready the only error with the Github Actions is that the 3.5.0 already exists, so I propose to update it to 3.6.0 (minor change since it adds new functionality https://semver.org/)