### PR TITLE
Fix bridge lib copy on windows

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -15,22 +15,13 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 
-# List of absolute paths to libraries that should be bundled with the plugin
-set(openpgp_bundled_libraries
-  ""
-  PARENT_SCOPE
-)
-
 set(BUILD_BUNDLE_DIR "$<TARGET_FILE_DIR:${BINARY_NAME}>")
-# Make the "install" step default, as it's required to run.
-set(CMAKE_VS_INCLUDE_INSTALL_TO_DEFAULT_BUILD 1)
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  set(CMAKE_INSTALL_PREFIX "${BUILD_BUNDLE_DIR}" CACHE PATH "..." FORCE)
-endif()
 
-set(INSTALL_BUNDLE_LIB_DIR "${CMAKE_INSTALL_PREFIX}")
 set(LIBOPENPGP_BRIDGE "libopenpgp_bridge.dll")
 set(LIBOPENPGP_BRIDGE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/shared/${LIBOPENPGP_BRIDGE}")
-install(CODE "file(REMOVE_RECURSE \"${INSTALL_BUNDLE_LIB_DIR}/${LIBOPENPGP_BRIDGE}\")" COMPONENT Runtime)
-install(FILES "${LIBOPENPGP_BRIDGE_PATH}" DESTINATION "${INSTALL_BUNDLE_LIB_DIR}" COMPONENT Runtime)
 
+# List of absolute paths to libraries that should be bundled with the plugin
+set(openpgp_bundled_libraries
+  ${LIBOPENPGP_BRIDGE_PATH}
+  PARENT_SCOPE
+)


### PR DESCRIPTION
Old CMake rules somehow did not result in copying libopenpgp_bridge.dll to final project.
New rules use linux rules as a template and copy the library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Windows plugin build configuration for improved clarity and maintainability. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->